### PR TITLE
Added Kivan's Proficiency tweak

### DIFF
--- a/bg1npc/bg1npc.tp2
+++ b/bg1npc/bg1npc.tp2
@@ -507,6 +507,19 @@ BEGIN @1116 DESIGNATED 131 /* The BG1 NPC Project: Sarevok's Diary Date Changes 
   BUT_ONLY_IF_IT_CHANGES
 
 
+BEGIN @1133 DESIGNATED 240 /* Kivan uses spears */
+  SUBCOMPONENT @1132 /* The BG1 NPC Project: Kivan's Proficiency */
+  GROUP @1065 /* The BG1 NPC Project: Tweaks */
+
+  INCLUDE "%MOD_FOLDER%/tweaks/kivan_spears.tpa"
+
+BEGIN @1134 DESIGNATED 241 /* Kivan uses halberds */
+  SUBCOMPONENT @1132 /* The BG1 NPC Project: Kivan's Proficiency */
+  GROUP @1065 /* The BG1 NPC Project: Tweaks */
+
+  INCLUDE "%MOD_FOLDER%/tweaks/kivan_halberds.tpa"
+
+
 /* BEGIN: Portrait Changes */
 /* Kivan */
 BEGIN @1027 DESIGNATED 150 /* The BG1 NPC Project: Kivan's "Kivan and Deheriana Companions" portrait */

--- a/bg1npc/tra/english/setup.tra
+++ b/bg1npc/tra/english/setup.tra
@@ -139,6 +139,9 @@
 @1129  = ~Banter Timing: Slow (about 40 minutes between banter dialogs)~
 @1130  = ~Banter Timing: Very slow (about 55 minutes between banter dialogs)~
 @1131  = ~The BG1 NPC Project: Give Coran his "Murder in Baldur's Gate" portrait~
+@1132  = ~The BG1 NPC Project: Kivan's Proficiency~
+@1133  = ~Kivan uses spears~
+@1134  = ~Kivan uses halberds~
 @5000  = ~BG:EE install detected.~
 @5001  = ~You must have BGT or TuTu installed for this component.~
 @5002  = ~You must have BGEE installed for this component.~

--- a/bg1npc/tweaks/kivan_halberds.tpa
+++ b/bg1npc/tweaks/kivan_halberds.tpa
@@ -1,0 +1,14 @@
+COPY_EXISTING_REGEXP "^%tutu_var%kivan[0-9]*\.cre" "override"
+  SET_BG2_PROFICIENCY PROFICIENCYSPEAR 0
+  SET_BG2_PROFICIENCY PROFICIENCYHALBERD 2
+
+  REPLACE_CRE_ITEM "%tutu_var%halb01" #0 #0 #0 "identified" "weapon1" EQUIP TWOHANDED
+
+
+COPY_EXISTING "x#kispr.itm" "override"
+  WRITE_SHORT 0x001c 0x1e
+  WRITE_BYTE 0x0031 0x62
+
+  IF_EXISTS
+
+

--- a/bg1npc/tweaks/kivan_spears.tpa
+++ b/bg1npc/tweaks/kivan_spears.tpa
@@ -1,0 +1,23 @@
+COPY_EXISTING_REGEXP "^%tutu_var%kivan[0-9]*\.cre" "override"
+  SET_BG2_PROFICIENCY PROFICIENCYSPEAR 2
+  SET_BG2_PROFICIENCY PROFICIENCYHALBERD 0
+
+  REPLACE_CRE_ITEM "%tutu_var%sper01" #0 #0 #0 "identified" "weapon1" EQUIP TWOHANDED
+
+
+COPY_EXISTING "%DryadFalls_Cave%.are" "override"
+  LAUNCH_PATCH_FUNCTION REPLACE_AREA_ITEM
+    STR_VAR
+    old_item	= "%tutu_var%halb02"
+    new_item	= "%tutu_var%sper02"
+  END
+
+
+COPY_EXISTING "%CloakwoodMines_L3%.are" "override"
+  LAUNCH_PATCH_FUNCTION REPLACE_AREA_ITEM
+    STR_VAR
+    old_item	= "%tutu_var%sper02"
+    new_item	= "%tutu_var%halb02"
+  END
+
+


### PR DESCRIPTION
Kivan's proficiency tweak, as discussed here: https://www.gibberlings3.net/forums/topic/32235-solution-to-kivan-his-spear-and-his-pips-in-halberd-for-bgee/

Two options are offered:
1) Kivan uses spears; this removes halberd proficiency from Kivan, adds two stars in spear, and changes his starting weapon into a spear.  It also changes the halberd +1 in the cave near Dryad Falls to a spear +1 (the halberd +1 is moved to Cloakwood mines instead)
2) Kivan uses halberds; this removes spear proficiency from Kivan, adds two stars in halberd, and changes his starting weapon to a halberd.  If installed, item x#kispr.itm is edited to have its item type and proficiency changed to halberd, but is otherwise unaltered (still looks and handles like a spear)

I did quick tests on BGEE and BGT, everything seems to work as designed.