### PR TITLE
Crossmod Compatibility with MPTweaks

### DIFF
--- a/bg1npc/phase2/baf/x#ajint2.baf
+++ b/bg1npc/phase2/baf/x#ajint2.baf
@@ -368,6 +368,7 @@ IF %BGT_VAR%
 AreaCheck("%NBaldursGate_DucalPalace_L1%")
 Global("NobleDopple","GLOBAL",1)
 Global("X#AjantisNobleDopple","GLOBAL",0)
+See([ENEMY])
 InParty(Myself)
 !StateCheck(Myself,CD_STATE_NOTVALID)
 InMyArea(Player1)


### PR DESCRIPTION
Ajantis was reacting to dopplegangers upon their 'command' to become dopplegangers, not actually seeing them.  This preemptive reaction interferred with MPTweaks ability to pause the game for multiplayer sessions.