### PR TITLE
BGGO compatible

### DIFF
--- a/bg1npc/phase2/baf/p#bg0900.baf
+++ b/bg1npc/phase2/baf/p#bg0900.baf
@@ -1,0 +1,12 @@
+IF %BGT_VAR%
+Global("P#ImanelExists","%WyrmsCrossing%",0)
+THEN
+RESPONSE #100
+SetGlobal("P#ImanelExists","%WyrmsCrossing%",1)
+CreateCreature("P#IMANEL",[601.617],14)
+CreateCreature("P#WOLF01",[624.611],15)
+CreateCreature("P#WOLF02",[554.608],14)
+CreateCreature("P#WOLF03",[623.555],0)
+CreateCreature("P#WOLF04",[562.566],13)
+CreateCreature("P#WOLF05",[507.581],9)
+END

--- a/bg1npc/phase2/tpa/bg1npc_kivan.tpa
+++ b/bg1npc/phase2/tpa/bg1npc_kivan.tpa
@@ -154,8 +154,14 @@ COMPILE EVALUATE_BUFFER ~bg1npc/Phase2/baf/P#WOLFA.BAF~// Compile script
 /* area script extension */
 ACTION_IF GAME_IS ~bgee eet~ THEN BEGIN
 /* BGEE needs different location for Imanel Silversword, as Simmeon from Dorn's quest spawns in Imanel's original BG1NPC location. */
-  EXTEND_BOTTOM ~%WyrmsCrossing_BCS%.bcs~ ~bg1npc/Phase2/baf/P#AR0900.BAF~
-    EVALUATE_BUFFER
+  /* With BGGO Alternative Wyrms Crossing: The city wall is in the way*/ 
+  ACTION_IF MOD_IS_INSTALLED "bggo.tp2" (ID_OF_LABEL "bggo.tp2" "baldurs_gate_graphical_overhaul_alternate" ) BEGIN 
+    EXTEND_BOTTOM ~%WyrmsCrossing_BCS%.bcs~ ~bg1npc/Phase2/baf/P#BG0900.BAF~
+      EVALUATE_BUFFER
+  END ELSE BEGIN
+    EXTEND_BOTTOM ~%WyrmsCrossing_BCS%.bcs~ ~bg1npc/Phase2/baf/P#AR0900.BAF~
+      EVALUATE_BUFFER
+  END
 END ELSE BEGIN
 /* For TuTu and BGT */
   EXTEND_BOTTOM ~%WyrmsCrossing_BCS%.bcs~ ~bg1npc/Phase2/baf/P#FW0900.BAF~


### PR DESCRIPTION
With BGGO Alternative Wyrms Crossing: The city wall is in the way.

If BGGO alternative maps are installed, new coordinates are automatically selected for the NPCs so that they are visible and not obscured by the city walls.