### PR TITLE
Fix Kivan sea elf quest sahuagin breaking with SCS

### DIFF
--- a/bg1npc/phase2/baf/x#saha01.baf
+++ b/bg1npc/phase2/baf/x#saha01.baf
@@ -1,3 +1,17 @@
+// Override script for Sahuagin Chieftain in Kivan's sea elf quest.
+// Prevents combat during the cutscene/dialogue phase (X#KivanSea=3).
+//
+// The CRE has EA=ENEMY but is set NEUTRAL by the cutscene via ChangeEnemyAlly.
+// Without this script, any mod that assigns default AI scripts to creatures
+// (e.g., SCS genai) will cause the sahuagin to attack before the chieftain's
+// dialogue can fire, permanently breaking the quest.
+//
+// Once the dialogue completes and sets X#KivanSea=5, this block no longer
+// matches and normal combat AI takes over.
 
-
-
+IF
+  Global("X#KivanSea","GLOBAL",3)
+THEN
+  RESPONSE #100
+    NoAction()
+END

--- a/bg1npc/phase2/baf/x#saha02.baf
+++ b/bg1npc/phase2/baf/x#saha02.baf
@@ -1,0 +1,9 @@
+// Override script for Sahuagin in Kivan's sea elf quest.
+// Same fix as x#saha01.baf -- see that file for details.
+
+IF
+  Global("X#KivanSea","GLOBAL",3)
+THEN
+  RESPONSE #100
+    NoAction()
+END

--- a/bg1npc/phase2/tpa/bg1npc_kivan.tpa
+++ b/bg1npc/phase2/tpa/bg1npc_kivan.tpa
@@ -261,6 +261,8 @@ EXTEND_BOTTOM ~%ShipwrecksCoast_BCS%.bcs~ ~bg1npc/Phase2/baf/P#FW3100.BAF~
 COMPILE EVALUATE_BUFFER ~bg1npc/Phase2/baf/X#IHTIA.BAF~
 COMPILE EVALUATE_BUFFER ~bg1npc/Phase2/baf/X#KETH.BAF~
 COMPILE EVALUATE_BUFFER ~bg1npc/Phase2/baf/X#KISE1.BAF~
+COMPILE ~bg1npc/phase2/baf/x#saha01.baf~
+COMPILE ~bg1npc/phase2/baf/x#saha02.baf~
 
 /* dialogues */
 COMPILE EVALUATE_BUFFER ~bg1npc/Phase2/dlg/X#KISEQU.D~


### PR DESCRIPTION
## Summary

The sahuagin creatures (X#SAHA01, X#SAHA02) in Kivan's sea elf quest have their override script slots populated (`x#saha01`, `x#saha02`) but no corresponding BCS files are ever compiled. This works fine in vanilla because the creatures have no AI and just stand idle until the dialogue turns them hostile.

However, when **Sword Coast Stratagems (SCS)** is installed, its `apply_genai_changes` system assigns default combat AI scripts (`dw2rp2mo`, `dw2rp2ge`) to the creature files. This causes a chain reaction during the cutscene at `X#KivanSea=3`:

1. The cutscene creates 2x X#SAHA02 but `ChangeEnemyAlly("X#SAHA02",NEUTRAL)` only targets the first match by death variable — the second stays EA=ENEMY
2. After `EndCutSceneMode()`, the ENEMY sahuagin's SCS default script fires and attacks the party
3. `GENSHT01` shout propagation (shout 89) causes all NEUTRAL sahuagin to call `Enemy()`
4. The chieftain's `StartDialogNoSet(Player1)` dialogue is interrupted or never fires
5. `X#KivanSea` never advances past 3, quest is permanently stuck

## Fix

Add override scripts for both sahuagin that block all lower-priority scripts during the dialogue phase (`X#KivanSea=3`). The scripts contain a single block:

```baf
IF
  Global("X#KivanSea","GLOBAL",3)
THEN
  RESPONSE #100
    NoAction()
END
```

This is the minimal fix: when `X#KivanSea=3`, the override script matches and prevents the default/general scripts from executing. Once the dialogue completes and sets `X#KivanSea=5`, the block stops matching and normal combat takes over.

The `ChangeEnemyAlly` duplicate death variable issue is a separate latent bug (only the first of two X#SAHA02 creatures gets set to NEUTRAL), but it's harmless with this fix in place — the second sahuagin was always ENEMY and ends up ENEMY after dialogue anyway.

## Changes

- `bg1npc/phase2/baf/x#saha01.baf` — replaced empty file with hold-during-dialogue override script
- `bg1npc/phase2/baf/x#saha02.baf` — new file, same override script
- `bg1npc/phase2/tpa/bg1npc_kivan.tpa` — added COMPILE statements for both BAF files

## Testing

Tested on a heavily modded EET installation (BG1NPC v32, SCS v35.21 with component 8110 "Improved Sahuagin" and component 5900 "Initialize AI"). With the fix, the quest progresses normally through all stages.